### PR TITLE
Fix check release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,12 +37,16 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-      - name: Install node dependencies (only for Windows because it can't find npm executable)
+      - name: Install node dependencies recursively (only for Windows because it can't find npm executable)
         if: runner.os == 'Windows'
         run: |
-          cd wollok_kernel/wollok_ts
-          npm install
-          cd ../..
+          for /R %%d in (package.json) do (
+            pushd "%%~dpd"
+            echo Installing in %%~dpd
+            npm install
+            popd
+          )
+        shell: cmd
       - name: Install Python dependencies
         run: |
           pip install -e ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           jupyter kernelspec list | grep wollok
 
   check_release:
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,14 +23,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.11"]
+        python-version: ["latest"]
         include:
           - os: windows-latest
-            python-version: "3.11"
           - os: ubuntu-latest
-            python-version: "3.11"
           - os: macos-latest
-            python-version: "3.11"
     steps:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,11 +41,13 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cd wollok_kernel
-          for /R %%f in (package.json) do (
-            echo Found package.json in: %%~dpf
-            pushd "%%~dpf"
-            npm install
-            popd
+          for /F "delims=" %%d in ('dir /B /S /A:D') do (
+            if exist "%%d\package.json" (
+              echo Found package.json in: %%d
+              pushd "%%d"
+              npm install
+              popd
+            )
           )
         shell: cmd
       - name: Install Python dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd wollok_kernel/wollok_ts
           npm install
-          cd ../..      
+          cd ../..
       - name: Install Python dependencies
         run: |
           pip install -e ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["latest"]
+        python-version: ["3.x"]
         include:
           - os: windows-latest
           - os: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Enable long paths
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
-      - name: Install Python dependencies
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install Python dependencies
         run: |
           pip install -e ".[test]"
       - name: Test with kernel tester

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
         if: runner.os == 'Windows'
         run: git config --system core.longpaths true
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      - name: Install node dependencies (only for Windows because it can't find npm executable)
+        if: runner.os == 'Windows'
+        run: |
+          cd wollok_kernel/wollok_ts
+          npm install
+          cd ../..      
       - name: Install Python dependencies
         run: |
           pip install -e ".[test]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,9 @@ jobs:
       - name: Install node dependencies recursively (only for Windows because it can't find npm executable)
         if: runner.os == 'Windows'
         run: |
-          for /R %%d in (package.json) do (
-            pushd "%%~dpd"
-            echo Installing in %%~dpd
+          for /R %%f in (package.json) do (
+            echo Found package.json in: %%~dpf
+            pushd "%%~dpf"
             npm install
             popd
           )

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: actions/setup-node@v4
-      - name: Install node dependencies
-        run: |
-          cd wollok_kernel/wollok_ts
-          npm install
-          cd ../..
+      # - name: Install node dependencies
+      #   run: |
+      #     cd wollok_kernel/wollok_ts
+      #     npm install
+      #     cd ../..
       - name: Install Python dependencies
         run: |
           pip install -e ".[test]"
@@ -62,11 +62,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install node dependencies (necessary to build Python dependencies)
-        run: |
-          cd wollok_kernel/wollok_ts
-          npm install
-          cd ../..
+      # - name: Install node dependencies (necessary to build Python dependencies)
+      #   run: |
+      #     cd wollok_kernel/wollok_ts
+      #     npm install
+      #     cd ../..
       - name: Install Python Dependencies
         run: |
           pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,14 +30,14 @@ jobs:
           - os: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: actions/setup-node@v4
-      # - name: Install node dependencies
-      #   run: |
-      #     cd wollok_kernel/wollok_ts
-      #     npm install
-      #     cd ../..
+        with:
+          node-version: 20
+      - name: Enable long paths
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
       - name: Install Python dependencies
+      - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
         run: |
           pip install -e ".[test]"
       - name: Test with kernel tester
@@ -49,7 +49,6 @@ jobs:
           jupyter kernelspec list | grep wollok
 
   check_release:
-    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -59,11 +58,6 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      # - name: Install node dependencies (necessary to build Python dependencies)
-      #   run: |
-      #     cd wollok_kernel/wollok_ts
-      #     npm install
-      #     cd ../..
       - name: Install Python Dependencies
         run: |
           pip install -e .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,7 @@ jobs:
       - name: Install node dependencies recursively (only for Windows because it can't find npm executable)
         if: runner.os == 'Windows'
         run: |
+          cd wollok_kernel
           for /R %%f in (package.json) do (
             echo Found package.json in: %%~dpf
             pushd "%%~dpf"

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -23,9 +23,9 @@ class CustomHook(BuildHookInterface):
         sys.path.insert(0, here)
         prefix = os.path.join(here, 'data_kernelspec')
 
+        self.find_and_install_npm_dependencies(start_dir=here)
+
         with TemporaryDirectory() as td:
-            self.find_and_install_npm_dependencies(td)
-            
             os.chmod(td, 0o755) # Starts off as 700, not user readable
             with open(os.path.join(td, 'kernel.json'), 'w') as f:
                 json.dump(kernel_json, f, sort_keys=True)

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -2,6 +2,7 @@ import os
 import sys
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 import subprocess
+import platform
 
 import argparse
 import json
@@ -23,7 +24,11 @@ class CustomHook(BuildHookInterface):
         sys.path.insert(0, here)
         prefix = os.path.join(here, 'data_kernelspec')
 
-        self.find_and_install_npm_dependencies(start_dir=here)
+        if platform.system() != "Windows":
+            self.find_and_install_npm_dependencies(start_dir=here)
+        else:
+            print("Skipping node dependencies installation on Windows")
+
 
         with TemporaryDirectory() as td:
             os.chmod(td, 0o755) # Starts off as 700, not user readable

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -50,7 +50,7 @@ class CustomHook(BuildHookInterface):
             if "package.json" in files:
                 print(f"package.json found in: {root}")
                 try:
-                    subprocess.run(["npm", "install"], cwd=root, check=True)
+                    subprocess.run(["npm", "install", "--verbose"], cwd=root, check=True)
                     print(f"✅ npm install completed in {root}\n")
                 except subprocess.CalledProcessError as e:
                     print(f"❌ Error executing npm install in {root}: {e}\n")

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
-
+import subprocess
 
 import argparse
 import json
@@ -24,6 +24,8 @@ class CustomHook(BuildHookInterface):
         prefix = os.path.join(here, 'data_kernelspec')
 
         with TemporaryDirectory() as td:
+            self.find_and_install_npm_dependencies(td)
+            
             os.chmod(td, 0o755) # Starts off as 700, not user readable
             with open(os.path.join(td, 'kernel.json'), 'w') as f:
                 json.dump(kernel_json, f, sort_keys=True)
@@ -38,3 +40,17 @@ class CustomHook(BuildHookInterface):
                     print("Custom logo files not found. Default logos will be used.")
 
             KernelSpecManager().install_kernel_spec(td, 'wollok', user=False, prefix=prefix)
+
+
+    def find_and_install_npm_dependencies(self, start_dir="."):
+        """Find and install npm dependencies for every package.json files in subfolders"""
+        print("Installing node dependencies")
+        subprocess.run(["pwd"])
+        for root, dirs, files in os.walk(start_dir):
+            if "package.json" in files:
+                print(f"package.json found in: {root}")
+                try:
+                    subprocess.run(["npm", "install"], cwd=root, check=True)
+                    print(f"✅ npm install completed in {root}\n")
+                except subprocess.CalledProcessError as e:
+                    print(f"❌ Error executing npm install in {root}: {e}\n")


### PR DESCRIPTION
Arreglamos el CI con el check release:

- el build de hatchling ahora hace una búsqueda recursiva de carpetas con package.json y les corre el npm install
- en Windows no funciona porque npm no está como ejecutable dentro del virtual environment que se crea, así que lo hacemos a mano en el CI y en el script de Python que hace el build de hatchling lo pasamos por alto
